### PR TITLE
Added instructions to generate doxygen docs

### DIFF
--- a/README
+++ b/README
@@ -54,6 +54,11 @@ make install
 There are no shared libraries!
 
 ==== USING (coming soon) ====
+Documentation:
+1) Ensure that Doxygen is installed before running ``cmake .``.
+2) ``make doc``
+3) Documentation is generated inside doc/doxygen/.
+
 See /usr/share/doc/examples for a number of examples of using the library. (coming soon)
 See tutorial/ for a tutorial (coming soon)
 


### PR DESCRIPTION
Doxygen isn't specified as a dependency. If a user installs it after ``cmake .``, the ``make doc`` target will not be generated. This PR adds instructions in the README to ensure that Doxygen is installed before the Makefile is generated.