### PR TITLE
Fixed typographical error, changed adminstrator to administrator in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ CTL has a number of dependencies. We have listed them below.
 We have made an effort to make getting an using these dependencies simple.
 
 In particular, we strongly recommend installing them on your system either
-as root or with the help of your system adminstrator via your operating systems
+as root or with the help of your system administrator via your operating systems
 package manager e.g. apt on debian based systems, yum on RHEL systems, or 
 brew/port/fink on OSX.
 


### PR DESCRIPTION
@appliedtopology, I've corrected a typographical error in the documentation of the [ctl](https://github.com/appliedtopology/ctl) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.