### PR TITLE
Implemented lookup table for finite field inversion

### DIFF
--- a/tests/test_finite_field.hpp
+++ b/tests/test_finite_field.hpp
@@ -51,3 +51,8 @@ TEST(FiniteField,Z11){
 		ASSERT_EQ(c/c,Z11(1));
 	}
 }
+
+TEST(FiniteField,InverterClass) {
+  ctl::detail::Inverter< 3 > inverter;
+  ASSERT_EQ(inverter.inverse(2), 2);
+}


### PR DESCRIPTION
If I understand C++ correctly, this design (with a singleton pattern carrying the actual lookup table) will keep instantiation of the actual lookup to once per program-and-prime.
